### PR TITLE
Altering slider variable to be in state namespace

### DIFF
--- a/source/commander/macros/slider.tid
+++ b/source/commander/macros/slider.tid
@@ -5,7 +5,7 @@ title: $:/plugins/kookma/commander/macros/slider
 type: text/vnd.tiddlywiki
 
 \define commander-slider(title)
-<$set name="revealState" value=<<qualify "$:/state-reveal-$title$">>>
+<$set name="revealState" value=<<qualify "$:/state/reveal/$title$">>>
 <h2>
   <$reveal type="nomatch" state=<<revealState>> text="yes">
     <$button class="tc-btn-invisible tc-tiddlylink" set=<<revealState>> setTo="yes">


### PR DESCRIPTION
The commander-slider macro was using the namespace `$:/state-reveal-` to
contain the state of whether the slider was expanded or not. However,
this creates a tiddler that core doesn't recognize as a state tiddler.

On NodeJS, this means clicking on that little arrow will write to disk.

On standalone tiddler files, this means clicking the arrow flags your
entire tiddlywiki as having unsaved changes.

By using the $:/state/ namespace for nonpersistent state, the slider's
non-persistent expand state will be treated as non-persistent by
Tiddlywiki.