### PR TITLE
Added Targets filter tiddler

### DIFF
--- a/source/commander/config/Targets.tid
+++ b/source/commander/config/Targets.tid
@@ -1,0 +1,3 @@
+title: $:/plugins/kookma/commander/config/Targets
+
+[[$:/temp/commander/selected-titles]indexes[]]

--- a/source/commander/field/macros/add-remove-set.tid
+++ b/source/commander/field/macros/add-remove-set.tid
@@ -5,10 +5,10 @@ title: $:/plugins/kookma/commander/field/macros/add-remove-set
 type: text/vnd.tiddlywiki
 
 \define add-new-field-bulk(newField:"Empty")
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable="ignore">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable="ignore">
 <$list filter="[<__newField__>] -Empty">
 <<create-log-tiddler "add-new-field-bulk">>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[!is[missing]] -[has:field[$newField$]]">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[!is[missing]] -[has:field[$newField$]]">
 <$fieldmangler>
 <$action-sendmessage $message="tm-add-field" $param=<<__newField__>> />
 </$fieldmangler>
@@ -20,10 +20,10 @@ type: text/vnd.tiddlywiki
 \end
 
 \define remove-old-field-bulk(oldField:"Empty")
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable="ignore">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable="ignore">
 <$list filter="[<__oldField__>] -Empty">
 <<create-log-tiddler "remove-old-field-bulk">>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[!is[missing]] +[has:field[$oldField$]]">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[!is[missing]] +[has:field[$oldField$]]">
 <$fieldmangler>
 <$action-sendmessage $message="tm-remove-field" $param=<<__oldField__>> />
 </$fieldmangler>
@@ -35,11 +35,11 @@ type: text/vnd.tiddlywiki
 \end
 
 \define set-field-value-bulk(fieldName:"Empty", fieldValue:"Empty")
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable="ignore">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable="ignore">
 <$list filter="[<__fieldName__>] -Empty">
 <$list filter="[<__fieldValue__>] -Empty">
 <<create-log-tiddler "set-field-value-create-bulk">>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[!is[missing]] -[$fieldName$[$fieldValue$]]">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[!is[missing]] -[$fieldName$[$fieldValue$]]">
 <$action-setfield $field=<<__fieldName__>> $value=<<__fieldValue__>> />
 <$macrocall $name="log-add-single-operation" msg="""field `$fieldName$` got a value""" tidItem=<<currentTiddler>> />
 </$list>

--- a/source/commander/field/uicomp/add-remove-fields.tid
+++ b/source/commander/field/uicomp/add-remove-fields.tid
@@ -20,7 +20,7 @@ placeholder=" new field"
 <$macrocall $name="remove-old-field-bulk" oldField={{$:/temp/commander/field-remove}} />
 </$button>
 <$select class="cmd-select-wd" tiddler="$:/temp/commander/field-remove" default=<<dummy>>>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]fields[]sort[]] -title -tags" >
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}fields[]sort[]] -title -tags" >
 <option><$view field="title"/></option>
 </$list>
 </$select>

--- a/source/commander/field/uicomp/set-field-value.tid
+++ b/source/commander/field/uicomp/set-field-value.tid
@@ -11,16 +11,16 @@ Field name &nbsp;
  tiddler="$:/temp/commander/field-name" 
  default="" 
 >
-<$list filter="[subfilter{$:/state/commander/set-field-value/fields}] ~[[$:/temp/commander/selected-titles]indexes[]fields[]sort[]] -tags -title" >
+<$list filter="[subfilter{$:/state/commander/set-field-value/fields}] ~[subfilter{$:/plugins/kookma/commander/config/Targets}fields[]sort[]] -tags -title" >
 <option><$view field="title"/></option>
 </$list>
 </$select> &nbsp; 
 <$checkbox 
  tiddler="$:/state/commander/set-field-value/fields" 
  field="text" 
- checked="[[$:/temp/commander/selected-titles]indexes[]fields[]sort[]]" 
- unchecked="[[$:/temp/commander/selected-titles]indexes[]fields[]sort[]] -[[$:/temp/commander/selected-titles]fields[]]"
- default="[[$:/temp/commander/selected-titles]indexes[]fields[]sort[]]"
+ checked="[subfilter{$:/plugins/kookma/commander/config/Targets}fields[]sort[]]" 
+ unchecked="[subfilter{$:/plugins/kookma/commander/config/Targets}fields[]sort[]] -[[$:/temp/commander/selected-titles]fields[]]"
+ default="[subfilter{$:/plugins/kookma/commander/config/Targets}fields[]sort[]]"
 > Include system fields?</$checkbox>
 
 Field value &nbsp;<$edit-text

--- a/source/commander/inspect/uicomp/Inspection.tid
+++ b/source/commander/inspect/uicomp/Inspection.tid
@@ -7,6 +7,6 @@ type: text/vnd.tiddlywiki
 
 <$macrocall 
  $name=compInspect
- filter="[[$:/temp/commander/selected-titles]indexes[]sort[]]"
+ filter="[subfilter{$:/plugins/kookma/commander/config/Targets}sort[]]"
  stateTiddler="temp/commander"
 />

--- a/source/commander/snr/macros/actions.tid
+++ b/source/commander/snr/macros/actions.tid
@@ -81,9 +81,9 @@ different
 \end
 
 \define search-replace-in-field-bulk()
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable="ignore">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable="ignore">
 <<create-log-tiddler "SNR operation">>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[!is[missing]]">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[!is[missing]]">
   <$macrocall 
     $name="search-replace-in-tiddler-field"
     tiddler=<<currentTiddler>> 
@@ -112,7 +112,7 @@ Replace?
 </$button>&nbsp;
 <!-- replace in bulk tiddler with confirmation -->
 <$macrocall $name="compConfirmAction"
-countFilter="[[$:/temp/commander/selected-titles]indexes[]]"
+countFilter={{$:/plugins/kookma/commander/config/Targets}}
 actionMacro="search-replace-in-field-bulk"
 stateTiddler="$:/state/commander/SelectiveReplaceAllDropdown"
 confirmMessage="Are you sure you wish to replace text in" 

--- a/source/commander/snr/macros/inputs.tid
+++ b/source/commander/snr/macros/inputs.tid
@@ -13,7 +13,7 @@ type: text/vnd.tiddlywiki
 <label>Tiddler title</label>
 <$select tiddler="$:/state/commander/snr/select-tiddler" default="" class="cmd-snr-textbox">
 <option value="">None</option>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]sort[]]" >
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}sort[]]" >
 <option value=<<currentTiddler>>><$text text=<<currentTiddler>>/></option>
 </$list>
 </$select>

--- a/source/commander/tag/macros/add-remove-replace.tid
+++ b/source/commander/tag/macros/add-remove-replace.tid
@@ -5,10 +5,10 @@ title: $:/plugins/kookma/commander/tag/macros/add-remove-replace
 type: text/vnd.tiddlywiki
 
 \define add-new-tag-bulk(newTag:"Empty")
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable="ignore">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable="ignore">
 <$list filter="[<__newTag__>] -Empty" variable=null>
 <<create-log-tiddler "add-new-tag-bulk">>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]!is[missing]!tag<__newTag__>]">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}!is[missing]!tag<__newTag__>]">
 <$fieldmangler>
 <$action-sendmessage $message="tm-add-tag" $param=<<__newTag__>> />
 </$fieldmangler>
@@ -20,10 +20,10 @@ type: text/vnd.tiddlywiki
 \end
 
 \define remove-old-tag-bulk(oldTag:"Empty")
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable=ignore>
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable=ignore>
 <$list filter="[<__oldTag__>] -Empty" variable=null>
 <<create-log-tiddler "remove-old-tag-bulk">>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]!is[missing]tag<__oldTag__>]">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}!is[missing]tag<__oldTag__>]">
 <$fieldmangler>
 <$action-sendmessage $message="tm-remove-tag" $param=<<__oldTag__>> />
 </$fieldmangler>
@@ -36,11 +36,11 @@ type: text/vnd.tiddlywiki
 
 
 \define replace-tag-bulk(oldTag:"Empty", newTag:"Empty")
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable="ignore">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable="ignore">
 <$list filter="[<__oldTag__>] -Empty" variable=null>
 <$list filter="[<__newTag__>] -Empty" variable=null>
 <<create-log-tiddler "replace-tag-bulk">>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]!is[missing]tag<__oldTag__>]">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}!is[missing]tag<__oldTag__>]">
 <$fieldmangler>
 <$action-sendmessage $message="tm-add-tag" $param=<<__newTag__>> />
 <$action-sendmessage $message="tm-remove-tag" $param=<<__oldTag__>>  />

--- a/source/commander/tag/uicomp/add-remove-tags.tid
+++ b/source/commander/tag/uicomp/add-remove-tags.tid
@@ -21,7 +21,7 @@ placeholder=" new tag"
 </$button>
 &nbsp;
 <$select class="cmd-select-wd" tiddler="$:/temp/commander/tag-add-remove/old" default=<<dummy>>>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]tags[]sort[]]" >
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}tags[]sort[]]" >
 <option><$view field="title"/></option>
 </$list>
 </$select>

--- a/source/commander/tag/uicomp/replace-tags.tid
+++ b/source/commander/tag/uicomp/replace-tags.tid
@@ -8,7 +8,7 @@ type: text/vnd.tiddlywiki
 
 <span style="display:inline-block;width:8ch;">Old tag &nbsp;</span>
 <$select class="cmd-select-wd" tiddler="$:/temp/commander/replace-tags/old" default=<<dummy>>>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]tags[]sort[]]" >
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}tags[]sort[]]" >
 <option><$view field="title"/></option>
 </$list>
 </$select>

--- a/source/commander/tiddler/macros/delete.tid
+++ b/source/commander/tiddler/macros/delete.tid
@@ -9,9 +9,9 @@ type: text/vnd.tiddlywiki
 \end
 
 \define delete-tiddlers-selective-bulk()
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable="ignore">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable="ignore">
 <<create-log-tiddler "delete-tiddler-selectively">>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]]" variable="Item">
+<$list filter={{$:/plugins/kookma/commander/config/Targets}} variable="Item">
 <$action-deletetiddler $tiddler=<<Item>> />
 <$macrocall $name="log-delete-selectively" item=<<Item>> />
 </$list>

--- a/source/commander/tiddler/uicomp/delete-tiddlers.tid
+++ b/source/commander/tiddler/uicomp/delete-tiddlers.tid
@@ -6,7 +6,7 @@ tags: $:/tags/Commander/TiddlerOps
 title: $:/plugins/kookma/commander/tiddler/uicomp/delete-tiddlers
 type: text/vnd.tiddlywiki
 
-<$set name=numTids value={{{[[$:/temp/commander/selected-titles]indexes[]count[]] }}}>
+<$set name=numTids value={{{[subfilter{$:/plugins/kookma/commander/config/Targets}count[]] }}}>
 <$reveal type="match" text="0" default=<<numTids>> >
 No tiddlers is selected for deleteion!
 </$reveal>
@@ -17,7 +17,7 @@ Note that, the delete operation cannot be undone!!
 </$set>
 
 <$macrocall $name="compConfirmAction"
-countFilter="[[$:/temp/commander/selected-titles]indexes[]]"
+countFilter={{$:/plugins/kookma/commander/config/Targets}}
 actionMacro="delete-tiddlers-selective-bulk"
 stateTiddler="$:/state/commander/SelectiveDeleteDropdown"
 />

--- a/source/commander/title/macros/prefix.tid
+++ b/source/commander/title/macros/prefix.tid
@@ -9,10 +9,10 @@ type: text/vnd.tiddlywiki
 \end
 
 \define addPrefix-to-tiltle-bulk(prefix:"Empty")
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable="ignore">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable="ignore">
 <$list filter="[<__prefix__>] -Empty" variable=null>
 <<create-log-tiddler "addPrefix-to-tiltle-bulk">>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[!is[missing]]">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[!is[missing]]">
 <$list filter="""[<currentTiddler>addprefix[$prefix$]] -[<currentTiddler>]""" variable="newTitle">
 <$list filter="[<newTitle>]  -[has[title]]" variable="ignore">
   <$action-sendmessage $message="tm-rename-tiddler" from=<<currentTiddler>> to=<<newTitle>> />
@@ -26,10 +26,10 @@ type: text/vnd.tiddlywiki
 \end
 
 \define removePrefix-from-tiltle-bulk(prefix:"Empty")
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable="ignore">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable="ignore">
 <$list filter="[<__prefix__>] -Empty" variable=null>
 <<create-log-tiddler "removePrefix-from-tiltle-bulk">>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[!is[missing]]">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[!is[missing]]">
 <$list filter="""[<currentTiddler>removeprefix[$prefix$]]   -[<currentTiddler>]""" variable="newTitle">
 <$list filter="[<newTitle>]  -[has[title]]" variable="ignore">
   <$action-sendmessage $message="tm-rename-tiddler" from=<<currentTiddler>> to=<<newTitle>> />

--- a/source/commander/title/macros/remove-cahrs-end.tid
+++ b/source/commander/title/macros/remove-cahrs-end.tid
@@ -5,7 +5,7 @@ title: $:/plugins/kookma/commander/title/macros/remove-cahrs-end
 type: text/vnd.tiddlywiki
 
 \define suffix-actions2()
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[prefix<sfx>]" variable="item">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[prefix<sfx>]" variable="item">
   <$action-sendmessage $message="tm-rename-tiddler" from=<<item>> to=<<sfx>> />
   <$macrocall $name="log-add-single-operation" msg="""characters removed from end. New title [[$(sfx)$]]""" tidItem=<<item>> />
 </$list>
@@ -16,7 +16,7 @@ type: text/vnd.tiddlywiki
 
 \define generate-suffixes2(n:"0")
 <$list filter="[<__n__>] -0" variable=null>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[!is[missing]]" variable="item">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[!is[missing]]" variable="item">
 <$list filter="""[<item>split[]butlast[$n$]join[]trim[]]""" variable="newTitle">
 <$text text=<<makelink2>>/>
 </$list>
@@ -25,13 +25,13 @@ type: text/vnd.tiddlywiki
 \end
 
 \define remove-chars-from-end-tiltle-bulk(num:"0")
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable="ignore">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable="ignore">
 <$list filter="[<__num__>] -0" variable=null>
 <<create-log-tiddler "remove-chars-from-end-tiltle-bulk">>
 <$vars n=<<__num__>> >
 <$wikify text="""<<generate-suffixes2 n:"$num$">>""" name="outputs">
  <$list filter="[subfilter<outputs>]" variable="sfx">
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[prefix<sfx>limit[2]count[]regexp[2]]" emptyMessage=<<suffix-actions2>> variable="cnt">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[prefix<sfx>limit[2]count[]regexp[2]]" emptyMessage=<<suffix-actions2>> variable="cnt">
 </$list>
 </$list>
 </$wikify>

--- a/source/commander/title/macros/remove-cahrs-start.tid
+++ b/source/commander/title/macros/remove-cahrs-start.tid
@@ -5,7 +5,7 @@ title: $:/plugins/kookma/commander/title/macros/remove-cahrs-start
 type: text/vnd.tiddlywiki
 
 \define suffix-actions()
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[suffix<sfx>]" variable="item">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[suffix<sfx>]" variable="item">
   <$action-sendmessage $message="tm-rename-tiddler" from=<<item>> to=<<sfx>> />
   <$macrocall $name="log-add-single-operation" msg="""characters removed from start. New title [[$(sfx)$]]""" tidItem=<<item>> />
 </$list>
@@ -16,7 +16,7 @@ type: text/vnd.tiddlywiki
 
 \define generate-suffixes(n:"0")
 <$list filter="[<__n__>] -0" variable=null>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[has[title]]" variable="item">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[has[title]]" variable="item">
 <$list filter="""[<item>split[]rest[$n$]join[]trim[]]""" variable="newTitle">
 <$text text=<<makelink>>/>
 </$list>
@@ -25,13 +25,13 @@ type: text/vnd.tiddlywiki
 \end
 
 \define remove-chars-from-begining-tiltle-bulk(num:"0")
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable="ignore">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable="ignore">
 <$list filter="[<__num__>] -0" variable=null>
 <<create-log-tiddler "remove-chars-from-begining-tiltle-bulk">>
 <$vars n=<<__num__>> >
 <$wikify text="""<<generate-suffixes n:"$num$">>""" name="outputs">
  <$list filter="[subfilter<outputs>]" variable="sfx">
- <$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[suffix<sfx>limit[2]count[]regexp[2]]" 
+ <$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[suffix<sfx>limit[2]count[]regexp[2]]" 
     emptyMessage=<<suffix-actions>> variable="cnt">
  </$list>
  </$list>

--- a/source/commander/title/macros/suffix.tid
+++ b/source/commander/title/macros/suffix.tid
@@ -10,9 +10,9 @@ type: text/vnd.tiddlywiki
 
 \define addSuffix-to-tiltle-bulk(suffix:"Empty")
 <$list filter="[<__suffix__>] -Empty" variable=null>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable="ignore">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable="ignore">
 <<create-log-tiddler "addSufffix-to-tiltle-bulk">>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[!is[missing]]">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[!is[missing]]">
 <$list filter="""[<currentTiddler>addsuffix[$suffix$]] -[<currentTiddler>]""" variable="newTitle">
 <$list filter="[<newTitle>]  -[has[title]]" variable="ignore">
   <$action-sendmessage $message="tm-rename-tiddler" from=<<currentTiddler>> to=<<newTitle>> />
@@ -27,9 +27,9 @@ type: text/vnd.tiddlywiki
 
 \define removeSuffix-from-tiltle-bulk(suffix:"Empty")
 <$list filter="[<__suffix__>] -Empty" variable=null>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[count[]] -0" variable="ignore">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[count[]] -0" variable="ignore">
 <<create-log-tiddler "removeSuffix-from-tiltle-bulk">>
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[!is[missing]]">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[!is[missing]]">
 <$list filter="""[<currentTiddler>removesuffix[$suffix$]] -[<currentTiddler>]""" variable="newTitle">
 <$list filter="[<newTitle>]  -[has[title]]" variable="ignore">
   <$action-sendmessage $message="tm-rename-tiddler" from=<<currentTiddler>> to=<<newTitle>> />

--- a/source/commander/title/uicomp/add-remove-chars.tid
+++ b/source/commander/title/uicomp/add-remove-chars.tid
@@ -9,7 +9,7 @@ type: text/vnd.tiddlywiki
 
 Number of characters
 <$select tiddler="$:/temp/commander/title-remove-chars"  default="0" class="cmd-sl">
-<$list filter="[[$:/temp/commander/selected-titles]indexes[]] +[!is[missing]] +[length[]] +[minall[]] +[subtract[1]] -Infinity" variable="minchars">
+<$list filter="[subfilter{$:/plugins/kookma/commander/config/Targets}] +[!is[missing]] +[length[]] +[minall[]] +[subtract[1]] -Infinity" variable="minchars">
 <$list filter=<<rngcat>> >
 <option value=<<currentTiddler>>><$view field='title'/></option>
 </$list>


### PR DESCRIPTION
This is a change I made while trying to address the whole checkbox,
commit, dropdown list thing. Instead of having every place reference the
indexes of the selected tiddlers list, instead, have a single configuration
tiddler which contains a filter used to obtain selected tiddlers.

 If someone wants to make the Commander dropdown list inclusive
rather than exclusive, they no longer have to touch all these files. They
only update that one filter. They could do away with the checkbox list
entirely and only have to edit one file.

In general, improves the hackability of Commander. There may be a few
other touches that must be done before this is correct though.